### PR TITLE
README.md: Add Links to Topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # mion-docs
 
-This mion docs website will provide documentation for all levels of users. 
+The [mion docs website](https://mion.docs.io) provide documentation for all levels of users.
+For viewing the contents directly from github, a list of topics is provided here.
+
+* [About](about.markdown)
+
+* [Quickstart](docs/quickstart.md)
+
+* [Resources](docs/resources.md)
+
+* [Glossary](docs/glossary.md)
+
+* [Image Types](docs/imagetypes.md)
+
+* [I^2C Issues](i2c-issues.md)
+
+* [Accessibility](ACCESSIBILITY.md)
+
+


### PR DESCRIPTION
There needed to be a way to navigate the documentation from github,
links to markdown pages added to README.md

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>