### PR TITLE
Fix Markdown Links in Accessibility Page

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -10,13 +10,13 @@ Accessibility
 =============
 
 This documentation endeavours to be as accessible as possible with respect to 
-the following the (World Wide Web Consortium's)[https://www.w3.org/] (w3c) (Web
-Accessibilty Initiative)[https://www.w3.org/WAI/] (WAI) and Web Content
+the following the [World Wide Web Consortium's](https://www.w3.org/) (w3c) [Web
+Accessibilty Initiative](https://www.w3.org/WAI/) (WAI) and Web Content
 Accessibility Guideline. To that end, any alterations to the
 repository must make sure that the following tools do not provide any errors
 from an accessibility point of view:
-* (`tota11y`)[https://khan.github.io/tota11y/] browser app;
-* (Google Chrome's Lighthouse)[https://developers.google.com/web/tools/lighthouse],
+* [`tota11y`](https://khan.github.io/tota11y/) browser app;
+* [Google Chrome's Lighthouse](https://developers.google.com/web/tools/lighthouse),
   running in incognito mode;
-* (WAVE )[https://wave.webaim.org/] Web Accessibility Evaluation Tool
+* [WAVE](https://wave.webaim.org/) Web Accessibility Evaluation Tool
 


### PR DESCRIPTION
I put the brackets in the wrong order...