### PR TITLE
Move Git Commandments and Style Guide Into NGL mion-docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,7 +64,8 @@ aria_logo: mion
 #   - vendor/cache/
 #   - vendor/gems/
 #   - vendor/ruby/
-
+exclude:
+  - _meta/
 
 aux_links:
   "Mion on GitHub":

--- a/_meta/git_commandments.md
+++ b/_meta/git_commandments.md
@@ -1,0 +1,40 @@
+# Git Commandments
+
+![Yey git](https://imgs.xkcd.com/comics/git.png  "git")
+
+**Git Workflow**
+
+For those new to git threre are a number of good guides provided by GitHub available [here](https://guides.github.com/)
+
+We follow the standard [GitHub Workflow](https://guides.github.com/introduction/flow/)
+- This applies to all of the main repos: mion, meta-mion, meta-mion-stordis, etc.
+- Changes must be made on a private branch named <username/brief_description_of_change>
+    * Please create a branch rather than a fork. A fork would be for a sibling project, that does not merge back into the default branch of the main project.
+- A pull request is created and the maintainers of the repo are added as reviewers
+- After the change is merged, the branch is deleted (this should be done during the merge)
+
+**GitHub Permissions**
+
+GitHub Teams are used to manage permissions to repos:
+
+- Mion Dev - grants write permission to the main Mion development repos
+
+**Git Commit Messages** 
+
+[General guidelines](https://chris.beams.io/posts/git-commit/#seven-rules) for writing good Git commits, the TL;DR is:
+- Subject line summarises the commit and is written in the imperative "Fix compile issue on X architecture"
+- Subject line limited to 50 chars, capitalised with no full stop
+- Body wrapped to 72 chars and explains what and why (not how)
+- Body references bugs/issues in GitHub
+
+In order to maintain the standards setup by the OpenEmbedded and Yocto Projects, we ask developers to utilize the same git commit standards used by these projects.
+
+[These standards](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines), are outlined here.
+
+Please read and adhere to these standards.
+
+**Git Branching strategy**
+
+seriously, lets not make it any more complicated than it needs to be.. 
+
+Our branches track the Yocto Project branches. Master tracks master in openembedded-core, Dunfell, dunfell, etc. Main development is being done on Dunfell for now, if additional resources are there we can start tracking master.

--- a/_meta/style_guide.md
+++ b/_meta/style_guide.md
@@ -1,0 +1,98 @@
+# mion Writing Style Guide
+This style guide is to provide some general guidelines for written 
+communications. It is being kept simple so as to allow individual voices to be 
+heard and in doing so form the collective voice of mion.
+
+## Spelling, Grammar, and Word Choice
+
+* In general US spelling of words, especially of technical terms, should be
+  used.
+
+* For date and time, use the International Organization for Standardization's 
+  (ISO) 8601 format: YYYY-MM-DD. See
+  [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) for more
+  information.
+  
+Try to avoid often used corporate buzzwords and phrases outside of their 
+original meaning:
+
+    * Disruptive 
+    * Synergy
+    * Closing the loop
+    * Wheelhouse
+    * +1
+    * Leverage
+    * Vertical
+    * Paradigm shift
+
+These words tend to lose their meaning over time, and can be viewed negatively
+by some. You may use them, but do so with consideration.
+
+> This can also apply to tech jargon. While both buzzwords and jargon can aid in 
+  communication, be mindful of your audience. 
+
+For all documents, be concise. Consider the following suggestion:
+**Delete all you can while retaining the statement's meaning and also avoiding 
+ambiguity and vagueness.**
+
+## Inclusivity and Supporting Diversity
+Some language can have negative, hurtful, or otherwise 
+biased/discriminatory meanings or uses that should be avoided.
+
+This section is not comprehensive, and is used to illustrate language which
+can be offensive, reinforce bias, or otherwise create exclusion, and may be used
+in a technical setting. In the future, there may be a "linter" for the style 
+guide: detection of biased-language will be flagged by the linter, but it is 
+still the responsibility of the writer to review documents.
+
+### Gender
+In generic circumstances, gender-neutral terms should be chosen. Rather than
+"he" or "she", try to use alternatives such as using the second person "you",
+or "they" for a generic single person. When referencing or quoting a 
+specific person use the pronouns they use.
+
+| Rather than...                                          | Consider...                                       |
+|---------------------------------------------------------|---------------------------------------------------|
+| When a programmer is stuck, *he* should talk to a duck. | When **you** get stuck, talk to a duck.           |
+| *He/she* can be a great listener.                       | **They** can be a great listener.                 |
+| Ms. Ducky has given me many hours of *their* time       | Ms. Ducky has given me many hours of **her** time |
+
+### Race and Ethnicity
+
+Some language to watch out for and alternatives:
+
+| Don't use...        | Consider...                               |
+|---------------------|-------------------------------------------|
+| Master/slave        | main/second, Primary/replica, Boss/Minion |
+| hang                | stops, freezes, doesn't respond           |
+| Blacklist/whitelist | blocklist/allowlist                       |
+
+> Keep in mind that it's permissible to use the outdated technical terms if
+  they exist within code being referenced, or a primary source of information 
+  that has not yet been updated. Consider making a note stating such if this 
+  is the case, however.
+
+### Accessibility 
+* Use the following web development tools to check for contrast and other
+  design elements which may effect readability or hinder a screen reader:
+  - [Google Chrome's Lighthouse](https://developers.google.com/~/lighthouse)
+  - [WAVE](https://wave.webaim.org/)
+  - [tota11y](https://khan.github.io/tota11y/) 
+* For images provide alternative text or use 
+  descriptive names for the files.
+
+## Miscellanea
+**Font**: When font choice is an option, please choose an open source font. 
+      Monospace fonts, such as [FiraCode](https://github.com/tonsky/FiraCode)
+      would be a good choice.
+
+**Format**: For technical documentation, use 
+[github](https://github.github.com/gfm/) flavored markdown.
+
+**Capitalization**: 'mion' should always be lowercase.
+
+**Column length**: 
+* **Markdown**: Column length must be done so that line breaks are rendered correctly: Two spaces after a line will cause a linebreak, which can accidently be entered when trying to keep lines under a certain length. It is often easier to not adhere to a set length.
+* **Git** commit messages, the maximum length is 72.
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
Files were placed for the time being into mion-docs/_meta, we may want
to consider moving them into mion-docs/docs in the future. For now they
are being excluded from docs.mion.io.

This commit closes mion-docs #96

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>