### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ For viewing the contents directly from github, a list of topics is provided here
 
 Want to contribute? First find a reported issue or open an issue for mion-docs [here](https://github.com/orgs/NetworkGradeLinux/projects/1).
 
-Then read our [git workflow](meta/git_commandments.md) and the [mion style guide](_meta/style_guide.md).
+Then read our [git workflow](_meta/git_commandments.md) and the [mion style guide](_meta/style_guide.md).
 
 If you have questions, feel free to ask us in our [slack channel](https://networkgradelinux.slack.com).


### PR DESCRIPTION
The readme had a typo in the link to the git commandments

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>