### PR TITLE
Revert "Add information on DCO and signing with GPG"

### DIFF
--- a/_meta/dco_and_signing.md
+++ b/_meta/dco_and_signing.md
@@ -1,9 +1,0 @@
-# Setting up Authentication and GPG signing
-Actual detailed tutorial coming soon!
-
-Learn right here how to set up authentication measures!
-
-But in the mean time, github has documentation here on setting up GPG signed
-commits:
-
-<https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/managing-commit-signature-verification>


### PR DESCRIPTION
Reverts NetworkGradeLinux/mion-docs#111

signing requirement not  actually required.