### PR TITLE
FIX: Fixed minor brand issues

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -12,7 +12,7 @@ Glossary
 Mion
 ---------
 * __BitBake Recipe__: Basic metadata file that describes the building of a package. Includes descriptions, locations
-* __`srunc`__: Simple `runc`; lightweight command line utility for managing containers in Mion.
+* __`srunc`__: Simple `runc`; lightweight command line utility for managing containers in mion.
 
 
 General

--- a/docs/i2c-issues.md
+++ b/docs/i2c-issues.md
@@ -11,8 +11,8 @@ I2C (I *squared* C) is a serial communication bus, useful for it's simple and
 low cost design.
 
 ONLP platform implementations often rely on i2c capability to talk to various
-hardware components. This functionality has changed greatly amongst kernel 
-versions, which ONL has been forced to handle. Because Mion provides a fixed
+hardware components. This functionality has changed greatly amongst kernel
+versions, which ONL has been forced to handle. Because mion provides a fixed
 kernel, this has platform maintainers will have to:
 
 * Make sure any implementations that use i2c headers directly are using the correct
@@ -24,17 +24,17 @@ BISDN established the majority of changes in this case.
 
 Detail
 ------
-The linux kernel provides two files of interest: `'linux/i2c.h` and 
+The linux kernel provides two files of interest: `'linux/i2c.h` and
 `linux/i2c-dev.h`. These were present in the initial commit of kernel 2.6.12 to
 GitHub which was released in 2005.
 
 The chief problem is that the `i2ctools` development library header file also
-provides `linux/i2c-dev.h`, with them defining different things throughout their 
+provides `linux/i2c-dev.h`, with them defining different things throughout their
 history. This is all fixed now, with `i2ctools` providing the `i2c/smbus.h` file
 instead, and (I believe), most of the other definitions being handled by the
 kernel headers.
 
-However, this is not as easy as that, with different base operating systems 
+However, this is not as easy as that, with different base operating systems
 having specific versions of `i2ctools` available to it. For ONL, the package
 repositories they use are Debian based, and as such:
 * Debian 8 (jessie) provides `i2ctools` version 3;
@@ -53,7 +53,7 @@ depending on the kernel version and whether `i2c-tools` is installed.
 While ONLP has a prepocessor conditional that can switch out which headers are
 included (`ONLPLIB_CONFIG_I2C_USE_CUSTOM_HEADER`), it's not strictly speaking
 "custom". The default is to use the custom header definitions
-(`linux/i2c-devices.h`), which as we have discussed, is already baked into the ONL 
+(`linux/i2c-devices.h`), which as we have discussed, is already baked into the ONL
 builder docker image.
 
 Further, some of the structures may be defined multiple times. The example that
@@ -62,17 +62,17 @@ both:
 * `linux/i2c.h`: in kernel since at least 2.6.12 going by GitHub history.
 * `linux/i2c-dev.h`: provided by i2c-tools (libi2c-dev) version 3.
 
-At least one vendor has declared a source file containing their own definition of 
+At least one vendor has declared a source file containing their own definition of
 `union i2c_smbus_data`, rather than go through the hassle of dealing with it
 externally.
 
-Finally, as it compares to Mion, we are not building the same kernels is
+Finally, as it compares to mion, we are not building the same kernels is
 ONL, and we are not using the same packaging, and therefore, ONL's solution may
 not work (this is platform dependent).
 
-The recipes for Mion, with the kernel version being used, means that:
+The recipes for mion, with the kernel version being used, means that:
 * `i2c-tools` version 4 is used;
-* The linux header do not include all the `smbus` defintions (i.e., 
+* The linux header do not include all the `smbus` defintions (i.e.,
   `i2c_smbus_data`) which are defined in:
 * `i2c/smbus.h`
 
@@ -86,16 +86,16 @@ Therefore:
       #else
       #include <linux/i2c-dev.h>
       #endif
-     
+
   This way, platforms don't have to update the i2c definitions everywhere.
-  Platforms that don't use the templates will have to add `-li2c` to the 
+  Platforms that don't use the templates will have to add `-li2c` to the
   `GLOBAL_LINK_LIBS` in their Makefiles for `onlpdump`/`onlps` and their platform
   library target.
 * Because i2c-tools 2 requires a library `libi2c0`, we need to add the relevant
-  linker flag to various targets. 
+  linker flag to various targets.
     * For platform code, this can either be done in the ONL provided templates
       (and therefore no changes to platform code), or if not, altered in the
-      platform target makefiles themselves. The templates can be found at 
+      platform target makefiles themselves. The templates can be found at
       `packages/base/any/onlp/builds/platform`.
     * For platform independent targets (e.g., `onlpd`), their Makefiles will also
       need to be updated. These are located in their respective directories at
@@ -104,4 +104,4 @@ Therefore:
       updated, but these are non-functional in the sense that they will be for
       things like unit-tests. The code that these repositories provide are modules
       and apart from testing, aren't really supposed to build themselves.
-  
+

--- a/docs/installing_mion.md
+++ b/docs/installing_mion.md
@@ -11,7 +11,7 @@ Installing Mion
 
 Introduction
 -------
-The Mion 0.9 release currently supports a single platform - the **APS Networks (Formally Stordis) BF2556X-1T**
+The Mion 0.9 release currently supports a single platform - the **APS Networks (Formally STORDIS) BF2556X-1T**
 
 Image types
 -------

--- a/docs/installing_mion.md
+++ b/docs/installing_mion.md
@@ -11,7 +11,7 @@ Installing Mion
 
 Introduction
 -------
-The Mion 0.9 release currently supports a single platform - the **APS Networks (Formally STORDIS) BF2556X-1T**
+The Mion 0.9 release currently supports a single platform - the **APS Networks (formerly STORDIS) BF2556X-1T**
 
 Image types
 -------

--- a/docs/installing_mion.md
+++ b/docs/installing_mion.md
@@ -11,26 +11,26 @@ Installing Mion
 
 Introduction
 -------
-The Mion 0.9 release currently supports a single platform - the **APS Networks (Formally Stordis) BF2556X-1T** 
+The Mion 0.9 release currently supports a single platform - the **APS Networks (Formally Stordis) BF2556X-1T**
 
 Image types
 -------
 
 Two build options are provided which build different types of images depending on the intended installation method:
 * Mender images produce a <image_name>.hddimg file which can be written to a USB key and installed on bare metal
-* Onie compliant image <image_name>.bin file which can be installed on a switch which has Onie installed
+* ONIE compliant image <image_name>.bin file which can be installed on a switch which has ONIE installed
 
 Mender
 -------
-The mender image can be flashed to a USB key using the dd command or a similar tool and plugged into the switch. 
+The mender image can be flashed to a USB key using the dd command or a similar tool and plugged into the switch.
 It will probably be necessary to change the boot order in in the switches UEFI (BIOS) so that it boots from the USB key.
 Once the USB key has sucessfully booted it will ask for confirmation to install the image
-**Pease not that this image is a bare metal image and will completly erase any other partitions such as Onie or other installed OSes**
+**Pease not that this image is a bare metal image and will completly erase any other partitions such as ONIE or other installed OSes**
 
-Onie
+ONIE
 -------
-The Onie image .bin file can be transfered installed on the system using any of the Onie supported installation methods found [here](https://opencomputeproject.github.io/onie/user-guide/index.html).
+The ONIE image .bin file can be transfered installed on the system using any of the ONIE supported installation methods found [here](https://opencomputeproject.github.io/onie/user-guide/index.html).
 In testing it has been found that a tftp server with a known hostname works well for installation but many other options are available.
-The Onie will be installed alongside other existing OSes, will not erase any of the hard drive and automatically updates the boot options.
+The ONIE will be installed alongside other existing OSes, will not erase any of the hard drive and automatically updates the boot options.
 
-**Please note that the Onie image does not currently support the simple-runc container system tooling.**
+**Please note that the ONIE image does not currently support the simple-runc container system tooling.**

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -11,10 +11,10 @@ Resources
 [Mion](https://mion.github.io)
 ------------------------------
 * [mion](https://github.com/aps-networks/mion) Base Mion github repositiory.
-* [meta-mion](https://github.com/APS-Networks/meta-mion) GitHub repository for 
+* [meta-mion](https://github.com/APS-Networks/meta-mion) GitHub repository for
   the base layer
 * [meta-mion-stordis](https://github.com/APS-Networks/meta-mion-stordis)
-  reference platform layer for Stordis BF2556x-1t switch, with ONLPv1 support.
+  reference platform layer for STORDIS BF2556x-1t switch, with ONLPv1 support.
 
 
 [The Yocto Project](https://www.yoctoproject.org/):
@@ -37,7 +37,7 @@ hardware. Maintains `bitbake` and OpenEmbedded Core.
 [OpenEmbedded](https://www.openembedded.org/wiki/Main_Page)
 -----------------------------------------------------------
 Build framework for embedded Linux
-* [OpenEmbedded-Core](https://www.openembedded.org/wiki/OpenEmbedded-Core): 
+* [OpenEmbedded-Core](https://www.openembedded.org/wiki/OpenEmbedded-Core):
   * Core support for machine architectures (x86-64, arm, etc)
   * Only builds for QEMU machines, and not physical targets
 * [Layer](https://www.openembedded.org/Layers_FAQ): A collection of recipes and configuration that can be used on top of OpenEmbedded Core.

--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ security and supportability at it's core.
 
 ---
 
-The key driver of this project is to provide an operating system designed for 
+The key driver of this project is to provide an operating system designed for
 operation in high-risk environments such as Critical National Infrastructure,
 and foster an inclusive and supportive community foundation.
 
@@ -31,7 +31,7 @@ essential.
 
 
 
-<!-- << HIGH LEVEL GOALS HERE >> 
+<!-- << HIGH LEVEL GOALS HERE >>
 ---------------------------    -->
 
 


### PR DESCRIPTION
**INTENT**
Fix minor typos in brand

**DETAIL**
ONIE and mion are brands, and should always be written with those respective cases (Unless, in the case of mion, its starting a sentence). This PR corrects those. Also, I seem to have a plugin that strips dangling white space, so that's happened as well. 