### PR TITLE
Add draft versions of the code of conduct and interpretation

### DIFF
--- a/_drafts/CODE_OF_CONDUCT.md
+++ b/_drafts/CODE_OF_CONDUCT.md
@@ -1,0 +1,81 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <ben@ageofpeers.com>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+
+## Interpretation
+
+See our Interpretation of the Code of
+Conduct:https://github.com/NetworkGradeLinux/mion-docs/blob/dunfell/_drafts/CoC-interpretation.md

--- a/_drafts/CoC-interpretation.md
+++ b/_drafts/CoC-interpretation.md
@@ -1,0 +1,68 @@
+# Interpretation of the Code of Conduct
+
+Taking inspiration from the [Linux Kernel Contributor Code of Conduct Interpretation](https://www.kernel.org/doc/html/latest/process/code-of-conduct-interpretation.html#code-of-conduct-interpretation),
+We are providing our interpretation of the aforementioned Code of Conduct which
+has been adopted for use for mion; this allows for
+adaptation specific to our project.
+
+As the mion project grows and changes over time, so may our interpretation.
+Expect this document to be subject to change. Changes to our
+interpretation, if and when they do occur, will be announced through the
+appropriate community communication channels, and a changelog will be attached
+at the end of this document.
+
+## Standards
+
+While the Code of Conduct provides examples of behavior that contributes to a
+positive environment, we acknowledge that these are only examples, and that they
+serve as a point of reference; that is, the behavior we expect in our community
+goes beyond the examples.
+
+We also believe that our standards should not only avoid being disrespectful or
+harmful, but should work towards the goal of actively welcoming others into the
+community. In other words, we strive to create an environment where individuals
+know that they will be respected and welcomed before they joined and not only
+after they have done so.
+
+In line with our standards is our
+[style-guide](https://github.com/NetworkGradeLinux/mion-docs/blob/dunfell/_meta/style_guide.md),
+which we expect contributors to be familiar with, and to follow our guidelines
+on Inclusivity and Supporting Diversity.
+
+## Responsibilities
+
+### Maintainers
+
+#### Definition of Maintainers
+
+When referenced in the Code of Conduct, maintainer applies to those
+responsible for the approval of merging branches, acceptance of patches, and
+general maintenance of any repository belonging to Network Grade Linux.
+
+The term also extends to the individual or individuals who monitor general
+communication channels such as, but not limited to any Slack channels not
+specific to a given repository. This role belongs to the project team contact
+or contacts provided under the Enforcement section of our Code of Conduct.
+
+The maintainers are generally listed within each repository `README.md`.
+
+#### Code of Conduct Responsibilities for Maintainers
+
+Our maintainers are expected to model the Code of Conduct, and to address
+unacceptable behavior. Responses to possible violations are expected to be
+performed in a timely manor, while also taking the time to communicate with the
+project's leaders to ensure that any actions taken are done so in a thoughtful
+manor which represents our values.
+
+## Scope
+
+The scope extends to accounts which submit patches and pull requests, such as on
+github.
+
+## Enforcement
+
+It is preferable that reports are submitted to the project team lead mentioned
+under the Code of Conduct. That said, it is also expected that all maintainers
+and project leadership will monitor the community, actively addressing
+situations by discussing possible violation with leadership, rather than only
+taking action when a report is made.


### PR DESCRIPTION
CODE_OF_CONDUCT.md and CoC-interpretation.md added to _drafts folder
for review. Upon approval, the location of the documents will change,
with both being added to mion-docs/docs and CODE_OF_CONDUCT.md being
added to mion repository.

This applies to mion#17

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>