### PR TITLE
Add supported switch table

### DIFF
--- a/docs/supported-switches.md
+++ b/docs/supported-switches.md
@@ -1,0 +1,13 @@
+# mion supported switches
+
+mion 2021.03 **Blasket** supports the following switches. To add a new switch,
+we have a [mion porting guide](https://github.com/NetworkGradeLinux/meta-mion-bsp/blob/dunfell/PORTING.md).
+
+|Vendor|Model|Arch|ASIC|Config|First Release|
+|---|---|---|---|---|---|
+|APS (Stordis)|BF2556X-1T|x86_64|BF Tofino 1|1U 48x25GB + 8x100GB|2020.12|
+|APS (Stordis)|BF6064X-T|x86_64|BF Tofino 1|2U 64x40/50/100Gb|2020.12|
+|Edgecore|ASGvOLT-64|x86_64| Broadcom Qumran-AX|2U 64xGPON + 2x100GB|2020.12|
+| Edgecore | Wedge100BF-32X | x86_64 | BF Tofino 1 | 1U 32x100Gb | 2020.12 |
+| Edgecore | Wedge100BF-65X | x86_64 | BF Tofino 1 | 2U 65x100Gb | 2020.12 |
+| QEMU     | qemux86-64     | x86_64 | --          | --          | 2021.03 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Home: index.md
   - Getting Started Guide: getting-started.md
   - Installing mion: installing_mion.md
+  - Supported switches: supported-switches.md
   - Resources: resources.md
   - Image Types: imagetypes.md
   - Trusted Platform Module: trusted-platform-module.md


### PR DESCRIPTION
A table of switches that are supported for mion 2021.03 Blasket has been
added to the main documentation.

This will be deployed to the gh-pages branch after merge into dunfell.

This commit checks off an item on mion-docs #179

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>