### PR TITLE
Update home page

### DIFF
--- a/docs/community/Community.md
+++ b/docs/community/Community.md
@@ -16,6 +16,10 @@ Each repository may have different requirements for contributing, in which case
 it can be found in the `CONTRIBUTING.md` in the repository's root. For an
 overview of how to contribute, including patch guidelines and git workflow, see
 [mion/CONTRIBUTING.md](https://github.com/NetworkGradeLinux/mion/blob/dunfell/CONTRIBUTING.md).
+We also have our
+[developer wiki](https://github.com/NetworkGradeLinux/mion-docs/wiki) with
+meeting minutes, development process, and other information for those who are
+getting involved with contributing.
 
 ## Getting in Touch
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,9 @@ security and supportability at it's core.
 
 [View it on GitHub](https://github.com/NetworkGradeLinux/mion-docs)
 
+> Greetings and welcome to our mion documentation site. Before continuing, it's
+always a good idea to check the version selector in the upper left menu.
+
 mion provides a network operating system(NOS) focusing on enterprise level
 managed switches with support for the [Open Network Install Environment(ONIE)](http://onie.org/)
 and the [Open Network Linux Platform API](https://opencomputeproject.github.io/OpenNetworkLinux/onlp/).
@@ -28,4 +31,13 @@ community is core.
 
 If you'd like to jump right in, check out our [getting started guide](getting-started.md),
 or see our [community](community/Community.md) page on how you can get
-involved or to simply say hello!
+involved, or to simply say hello!
+
+> © 2021 Network Grade Linux. Copyright © 2021 Network Grade Linux The Linux
+Foundation® . All rights reserved. The Linux Foundation has registered
+trademarks and uses trademarks. For a list of trademarks of The Linux
+Foundation, please see our
+[Trademark Usage page](https://www.linuxfoundation.org/trademark-usage) page.
+Linux is a registered trademark of Linus Torvalds.
+[Privacy Policy](https://www.linuxfoundation.org/privacy)
+and [Terms of Use](https://www.linuxfoundation.org/terms).


### PR DESCRIPTION
A note about version selection, and a copyright notice was added to
the home page. The dev wiki link that was going to be added was instead
added to the community page, as it felt awkward on the home page.

This commit checks off a box for mion-docs #179
Signed-off-by: Katrina Prosise <igorina@toganlabs.com>