### PR TITLE
Remove mender from documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,9 +139,6 @@ that issue,or just want to be sure, you can use `-v <VENDOR>` to specify.
 
 ```shell
 
-# Builds an ONLPV1 Guest, installs it on a mender updatable host and autostarts
-../mc_build.sh -m stordis-bf2556x-1t -c guest:mion-guest-onlpv1 -h host-mender:mion-host
-
 # Builds just an ONLPV1 Guest. Useful for creating update artifacts.
 ../mc_build.sh -m stordis-bf2556x-1t -c guest:mion-guest-onlpv1
 
@@ -149,10 +146,10 @@ that issue,or just want to be sure, you can use `-v <VENDOR>` to specify.
 ../mc_build.sh -m stordis-bf2556x-1t -h host-onie:mion-onie-image-onlpv1
 
 # Builds an image with ONLPV2 and ONLPV1 guests but disables ONLPV1 guest
-../mc_build.sh -m stordis-bf2556x-1t -c guest:mion-guest-onlpv1,guest:mion-guest-onlpv2 -h host-mender:mion-host -d mion-guest-onlpv1
+../mc_build.sh -m stordis-bf2556x-1t -c guest:mion-guest-onlpv1,guest:mion-guest-onlpv2 -h host-onie:mion-host -d mion-guest-onlpv1
 
 # Emits the commandline to build an image with ONLPV2 and ONLPV1 guests but disables ONLPV1 guest
-../mc_build.sh -e -m stordis-bf2556x-1t -c guest:mion-guest-onlpv1,guest:mion-guest-onlpv2 -h host-mender:mion-host -d mion-guest-onlpv1
+../mc_build.sh -e -m stordis-bf2556x-1t -c guest:mion-guest-onlpv1,guest:mion-guest-onlpv2 -h host-onie:mion-host -d mion-guest-onlpv1
 # Builds a qemu image with ONLPV1, useful for testing purposes
 ../mc_build.sh -v qemu -m qemux86-64 -h host-onie:mion-image-onlpv1
 

--- a/docs/imagetypes.md
+++ b/docs/imagetypes.md
@@ -30,5 +30,4 @@ The following self-explanatory config files can be found in
 
 * **guest.conf**
 * **host.conf**
-* **host-mender.conf**
 * **host-onie.conf**

--- a/docs/installing_mion.md
+++ b/docs/installing_mion.md
@@ -6,19 +6,13 @@ machine configuration.
 
 ## Image types
 
-* Mender images(`<image_name>.hddimg`):
-  write to a USB key to install on bare metal
 * ONIE compliant images (`<image_name>.bin`): install on a switch with ONIE
   installed
 
-## Mender
+## Mender (DEPRECATED)
 
-Flash the mender image to a USB key `dd` or similar tool.
-If needed, change the boot order in UEFI (BIOS) to boot from the USB key. You
-will ask for confirmation to install the image.
-
-> **This image is a bare metal image that erases any other partition, such as**
-**ONIE or other installed OSes**
+Mender images are no longer included **after**
+["Copeland"](https://docs.mion.io/2021.03/installing_mion/).
 
 ## ONIE
 


### PR DESCRIPTION
All mentions of mender have been removed or in the case of
`installing_mion.md`, amended to add that it is now
deprecated and linked to older documentation.

This applies to mion-docs #195

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>

# mion-docs

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: _#?_

## Build and test
- [x] Build command: `mike deploy 2021.06-dev`
- [x] Smoke tested on: ` http://localhost:8000/`
- [x] _all other steps taken to validate the pull request_

## Checklist
- [x] All relevant issues have been updated
- [x] Reviewers have been added and a maintainer has been assigned
- [x] A Label, Project and Milestone have all been added
- [x] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [x] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [x] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
