### PR TITLE
Add onie only build info to adds-and-ends.md

### DIFF
--- a/docs/adds-and-ends.md
+++ b/docs/adds-and-ends.md
@@ -53,7 +53,12 @@ The kernel module is automatically loaded on boot and will create a device node
 
 ## Newly Added Features
 
-## containerd ad K3s
+mion ONIE images can be built without the complication of the multiconfig
+by using the timely `cronie.sh` build script; this is now the default
+approaching for building mion.
+
+### containerd ad K3s
+
 [Containers are implemented using containerd and K3s](mion-container-support.md)
 
 ## Ends


### PR DESCRIPTION
Basic shoutout to cronie.sh, which may be embellished a bit later on.

Page renders correctly using grip, and passes markdownlint check.

This commit closes mion-docs #206

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>

# mion-docs

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: _#?_

## Build and test
- [ ] Build command: _e.g. mc_build.sh ..._
- [ ] Smoke tested on: _e.g. stordis bf2556x-1t_
- [ ] _all other steps taken to validate the pull request_

## Checklist
- [ ] All relevant issues have been updated
- [ ] Reviewers have been added and a maintainer has been assigned
- [ ] A Label, Project and Milestone have all been added
- [ ] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [ ] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [ ] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
