### PR TITLE
Document new features for 2021.06

### DIFF
--- a/docs/adds-and-ends.md
+++ b/docs/adds-and-ends.md
@@ -1,14 +1,19 @@
 # Adds and Ends
 
-mion has a few **additional** features that are use-case specific, but don't
-warrant their own page. Then there are features that are experimental or not
-fully tested, or were newly added right before a release, and may be of
-interest. Lastly, features or packages that will be phased out of mion.
+mion has **additional** features that are:
+
+* use-case specific or niche, and don't need their own page
+* very new
+* experimental or not fully tested
+* to be phased out of mion.
+
+You'll find the above and more, here at *Adds and Ends*.
 
 > This is also a good time to remind you to check that you're reading the
 correct documentation version.
 
-Read the [release notes](release_notes/2021-03.md) for full list of changes.
+While there's some overlap, you should read the
+[release notes](release_notes/2021-06.md) for full list of changes.
 
 ## Additional Features
 
@@ -30,7 +35,7 @@ This will include tools for building and debugging on the target.
 
 As of mion 2021.03, qemux86-64 mion image with ONLPv1 support can be built.
 The primary purpose of this qemu image is to support testing, such as
-[p-tests and OpenEmbedded runtime tests](https://github.com/NetworkGradeLinux/mion-docs/wiki/Test-plan).
+[p-tests and OpenEmbedded runtime tests](https://github.com/NetworkGradeLinux/mion-docs/wiki/Automated-testing).
 
 Outside of internal testing purposes, the qemu image can give you a quick look
 at mion without the need to install it on bare-metal.
@@ -53,6 +58,8 @@ The kernel module is automatically loaded on boot and will create a device node
 
 ## Newly Added Features
 
+### ONIE Only Image Creation
+
 mion ONIE images can be built without the complication of the multiconfig
 by using the timely `cronie.sh` build script; this is now the default
 approaching for building mion.
@@ -60,6 +67,11 @@ approaching for building mion.
 ### containerd ad K3s
 
 [Containers are implemented using containerd and K3s](mion-container-support.md)
+
+### Ptest Images
+
+OpenEmbedded provides ptests, which in short are tests that are included with a
+package and have been configured via a recipe to summarize the results.
 
 ## Ends
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,7 +82,9 @@ We added the cake.*
 
 ## Obtaining mion Sources
 
-You're almost ready. Obtain the *required* mion bitbake layers:
+You're almost ready! Now obtain the *required* mion bitbake layers. Use either
+the script `mion/contrib/clone_mion_repos.sh`, which clones all the
+main public mion repos with a single command, or manually as shown below.
 
 ```shell
 # To clone the submodules, `--recursive` is required
@@ -96,16 +98,12 @@ git clone https://github.com/NetworkGradeLinux/meta-mion-bsp.git
 git clone https://github.com/NetworkGradeLinux/meta-mion-backports.git
 ```
 
-Alternatively, the script `mion/contrib/clone_mion_repos.sh` will clone all of
-the main public mion repos with a single command.
-
 `mion` provides the build script (cronie.sh) and configuration files in
 `build/conf/`. The `meta-mion` layer provides mion distro configuration, and
-`meta-mion-bsp` is were support and configuration is found.
+`meta-mion-bsp` is where support and configuration is found.
+[Resources](resources.md) provides a detailed listing of all active mion repos.
 
-> 
-
-## Basic Usage
+## Basic Usage of Build Environment
 
 To begin, set up the build environment using the OpenEmbedded init script:
 
@@ -163,7 +161,6 @@ this:
 
 From the build directory, you'll find the finished images and related items such
 as the onie-installer in `tmp-glibc/deploy/images/<VENDOR>-<MACHINE>/`
-TODO: fact check onie-installer still in use
 
 ### Build Process
 
@@ -180,10 +177,8 @@ down as follows:
 You're finally done with this guide? Now it's time for
 [Installing mion](installing_mion.md)!
 
-If you've built the qemu image, from the build directory, run:
+If you've built the qemu image, from the build directory,
+`runqemu tmp-glibc/deploy/images/qemux86-64/`
 
 > runqemu may require setting up a tap interface. See `meta-mion-qemu/README`
 for more information.
-
-`runqemu tmp-glibc/deploy/images/qemux86-64/`
-

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,9 +1,9 @@
 # Glossary
 
-## Yocto Project and mion
+## Yocto Project, OpenEmbedded, and mion
 
 * **mion**: Mini Infrastucture Operating System for Networks
-* **Open Embedded**: [Build framework](https://www.openembedded.org/wiki/Main_Page)
+* **OpenEmbedded**: [Build framework](https://www.openembedded.org/wiki/Main_Page)
   used by the Yocto Project
 * **recipe**: a set of instructions related to the fetching, building, or
   installation of a program within the Yocto Project

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -6,15 +6,23 @@
   information regarding the internal development of mion and work in progress
 * [Network Grade Linux](https://github.com/NetworkGradeLinux): Parent project of
   mion
+  
+### mion Repos
+
 * [mion](https://github.com/NetworkGradeLinux/mion): Base mion GitHub repository
 * [meta-mion](https://github.com/NetworkGradeLinux/meta-mion): GitHub repository
   for the base distro layer
-* [meta-mion-bsp](https://github.com/NetworkGradeLinux/meta-mion-bsp/)
+* [meta-mion-bsp](https://github.com/NetworkGradeLinux/meta-mion-bsp/):
   Board/machine configurations and support layers
-* [meta-mion-sde](https://github.com/NetworkGradeLinux/meta-mion-sde/)
+* [meta-mion-sde](https://github.com/NetworkGradeLinux/meta-mion-sde/):
   Recipes needed to enable switch ASIC functionality
-* [meta-mion-backports](https://github.com/NetworkGradeLinux/meta-mion-backports/)
-  Recipes backported from other Yocto project repos
+* [meta-mion-backports](https://github.com/NetworkGradeLinux/meta-mion-backports/):
+  Recipes backported from other Yocto project repos, such as K3s support
+* [meta-mion-stratum](https://github.com/NetworkGradeLinux/meta-mion-stratum):
+  [Stratum Support](https://github.com/NetworkGradeLinux/mion-docs/wiki/Stratum).
+  Currently dependent on `meta-mion-sde`.
+* [meta-mion-unsupported](https://github.com/NetworkGradeLinux/meta-mion-unsupported):
+  layers which are not currently supported, such as meta-mion-simplerunc
 
 ## Yocto Project and OpenEmbedded
 

--- a/docs/stratum.md
+++ b/docs/stratum.md
@@ -1,0 +1,30 @@
+# Stratum Support in mion
+
+The [Stratum](https://opennetworking.org/stratum/) project provides an
+open-source SDN stack, with source code available via
+[Stratum GitHub](https://opennetworking.org/stratum/).
+
+The [meta-mion-stratum](https://github.com/NetworkGradeLinux/meta-mion-stratum)
+layer provides the recipes.
+
+> Note: the stratum recipe simply downloads the .deb archive provided by the
+Stratum project and extracts the contents (binaries, libraries and scripts) to
+the correct location on the mion filesystem.
+
+## Installing Stratum
+
+1. Stratum currently depends on the Barefoot SDE - [Installing Barefoot SDE](Barefoot-SDE)
+2. Clone the `meta-mion-stratum` layer to your mion directory
+`git clone git@github.com:NetworkGradeLinux/meta-mion-stratum.git`
+3. Add the `meta-mion-stratum` layer to `build/conf/bblayers.conf`
+4. Add the following to the bottom of `build/conf/local.conf`:
+   `IMAGE_INSTALL += " stratum"`
+5. Build and install an image as normal.
+
+### Starting Stratum
+
+* [Stratum documentation](https://github.com/stratum/stratum/blob/main/README.md)
+
+The Stratum start-up script is `/usr/bin/start-stratum.sh` which can also be
+viewed in the
+[Stratum repo](https://github.com/stratum/stratum/blob/main/stratum/hal/bin/barefoot/deb/start-stratum.sh).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - Supported Switches: supported-switches.md
   - Resources: resources.md
   - mion Container Support: mion-container-support.md
+  - Stratum: stratum.md
   - Glossary: glossary.md
   - Adds and Ends: adds-and-ends.md
   - Release Notes: 


### PR DESCRIPTION
Some, though not all, new features and supported solutions have been
documented. Absent is SDE upgrade info, TN48m and DENT, which will be
done in a separate commit after those items have been added to the wiki.

Page rendering and links were checked locally and no issues were found
that relate to changes made in this commit.

This commit applies to mion-docs#219

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>

## Build and test
- [x] Build command: `mkdocs serve`
- [x] Smoke tested on: N/A
- [x] all other steps taken to validate the pull request

## Checklist
- [x] All relevant issues have been updated
- [x] Reviewers have been added and a maintainer has been assigned
- [x] A Label, Project and Milestone have all been added
- [x] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [x] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [x] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
