### PR TITLE
Apply style-guide rules to mion-docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,10 +167,10 @@ In a terminal:
 git add path/filename
 
 # commit time!
-git commit --signoff
+
 ```
 
-> This will start the default editor defined in your git config. To change, run
+> This will start the default editor defined in your git config. To change, run:
 `git config --global core.editor name_of_editor`
 
 If you need help with the commit message, refer back to
@@ -182,7 +182,7 @@ Almost done! Now it's time to push your branch onto GitHub:
 
 Lastly, go to <https://github.com/NetworkGradeLinux/mion-docs> and submit a pull
 request for your branch to be merged with dunfell. We will let you know if
-there're any issues and what corrections need to be made. After your pull
+there are any issues and what corrections need to be made. After your pull
 request is merged, delete your branch from the remote repo. (Though you can keep
 it on your computer if you want to)
 

--- a/docs/adds-and-ends.md
+++ b/docs/adds-and-ends.md
@@ -38,7 +38,7 @@ open-source SDN stack, with source code available via
 The [meta-mion-stratum](https://github.com/NetworkGradeLinux/meta-mion-stratum)
 layer provides the recipes.
 
-> Note: the stratum recipe simply downloads the .deb archive provided by the
+> Note: the Stratum recipe simply downloads the .deb archive provided by the
 Stratum project and extracts the contents (binaries, libraries and scripts) to
 the correct location on the mion filesystem.
 

--- a/docs/community/Coc-interpretation.md
+++ b/docs/community/Coc-interpretation.md
@@ -26,7 +26,7 @@ know that they will be respected and welcomed before they joined and not only
 after they have done so.
 
 In line with our standards is our
-[style-guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-guide),
+[style-guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide),
 which we expect contributors to be familiar with, and to follow our guidelines
 on Inclusivity and Supporting Diversity.
 
@@ -58,7 +58,7 @@ mannor which represents our values.
 ## Scope
 
 The scope extends to accounts which submit patches and pull requests, such as on
-Github.
+GitHub.
 
 ## Enforcement
 


### PR DESCRIPTION
Grep'ed my way through for potential issues. Capitalization passed.
Didn't encounter incorrect variants of project or company names.

Note: This is for mion-docs, but does not cover the wiki, which will be
handled in a separate patch.

This contributes to mion-docs #219

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>

# mion-docs

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: _#?_

## Build and test
- [ ] Build command: _e.g. mc_build.sh ..._
- [ ] Smoke tested on: _e.g. stordis bf2556x-1t_
- [ ] _all other steps taken to validate the pull request_

## Checklist
- [ ] All relevant issues have been updated
- [ ] Reviewers have been added and a maintainer has been assigned
- [ ] A Label, Project and Milestone have all been added
- [ ] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [ ] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [ ] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
