### PR TITLE
Remove ONIE from qemu example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -132,8 +132,8 @@ that issue, or just want to be sure, you can use `-v <VENDOR>` to specify.
 # Builds an ONLPV1 image onie image
 ../cronie.sh -m stordis-bf2556x-1t mion-onie-image-onlpv1
 
-# Builds the same as above but for QEMU
-../cronie.sh -v qemu -m qemux86-64 mion-onie-image-onlpv1
+# Builds a QEMU with ONLPV1
+../cronie.sh -v qemu -m qemux86-64 mion-image-onlpv1
 
 ```
 


### PR DESCRIPTION
Updated the qemu example. As ONIE support has not been added for our
qemu, this won't build as it was.

This commit applies to mion-docs #219

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>

# mion-docs

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: _#?_

## Build and test
- [ ] Build command: _e.g. mc_build.sh ..._
- [ ] Smoke tested on: _e.g. stordis bf2556x-1t_
- [ ] _all other steps taken to validate the pull request_

## Checklist
- [ ] All relevant issues have been updated
- [ ] Reviewers have been added and a maintainer has been assigned
- [ ] A Label, Project and Milestone have all been added
- [ ] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [ ] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [ ] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
