### PR TITLE
Add note on build script argument order

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,6 +119,8 @@ arguments displays basic usage. **In general:**
 ../cronie.sh -m <machine> <image>
 ```
 
+**The <image> argument must be provided last**
+
 To do a "dry run" without running a build, add `-e` which emits what would have
 run if you ran this from bitbake.
 


### PR DESCRIPTION
`cronie.sh` requires that the image be provided last, however the
documentation didn't cover this.

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>

# mion-docs

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: _#?_

## Build and test
- [ ] Build command: _e.g. mc_build.sh ..._
- [ ] Smoke tested on: _e.g. stordis bf2556x-1t_
- [ ] _all other steps taken to validate the pull request_

## Checklist
- [ ] All relevant issues have been updated
- [ ] Reviewers have been added and a maintainer has been assigned
- [ ] A Label, Project and Milestone have all been added
- [ ] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [ ] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [ ] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
