### PR TITLE
Update use of cronie script use

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,10 +119,12 @@ arguments displays basic usage. **In general:**
 ../cronie.sh -m <machine> <image>
 ```
 
-**NOTE: The \<image\> argument must be provided last**
+Argument `<image>` must be provided last, as following arguments
+would be passed to bitbake as part of the image name.
 
 To do a "dry run" without running a build, add `-e` which emits what would have
-run if you ran this from bitbake.
+run if you ran this from bitbake. For bitbake to attempt continuing in the
+case of a build error, add `-k`.
 
 > Note: The script can not always determine the vendor name, if you encounter
 that issue, or just want to be sure, you can use `-v <VENDOR>` to specify.


### PR DESCRIPTION
added info about `-k` and did some minor changes to how "image name must
be last arg" was worded.

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>

# repo: mion

- Issue: [mion #140](https://github.com/NetworkGradeLinux/mion/issues/140)
- [Style-guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide) check [y/n]: y
- Rendered page viewed with: *grip*
- If instructional,
    - Affected hardware: *n/a*
    - Verified: Yes  
- Description: Updated the info about cronie usage and arg order
